### PR TITLE
fixed reqfile body re to match on double newline

### DIFF
--- a/processors/request/reqFileParser.go
+++ b/processors/request/reqFileParser.go
@@ -18,7 +18,7 @@ func FileToRequestAgent(reqContent string, urlBase string, proxy string, timeout
 	}
 	path := urlBase + pathGroups[1]
 
-	getContent := regexp.MustCompile(`(?s)\r\n\r\n(.*)`)
+	getContent := regexp.MustCompile(`(?s)(?:\r\n\r\n|\n\n)(.*)`)
 	bodyGroups := getContent.FindStringSubmatch(reqContent)
 	body := ""
 	if len(bodyGroups) > 1 {


### PR DESCRIPTION
Req files edited by vim remove carriage returns. This change adds support for double newlines as well as double crlf 